### PR TITLE
fix: mount -o loop needs type param

### DIFF
--- a/src/winusb
+++ b/src/winusb
@@ -362,7 +362,7 @@ trap "exitUmountIso '$isoMountPath' '$partitionMountPath' 'other signal'" HUP QU
 echo "Mounting..."
 mkdir -p "$isoMountPath"
 if [ -f "$isoPath" ]; then # ISO
-	mount -o loop "$isoPath" "$isoMountPath"
+	mount -o loop -t iso9660 "$isoPath" "$isoMountPath"
 else # Real DVD drive (block)
 	mount "$isoPath" "$isoMountPath"
 fi


### PR DESCRIPTION
Hello Slacka,

on my Gentoo Linux "mount -o loop" needs "-t iso9660" parameter as well. I'm not sure if it works without it in different environments - but this is the most reliable way for iso images.

Winusb is a great script, thanks for that!

Jaromir