### PR TITLE
Revert "fix: mount -o loop needs type param"

### DIFF
--- a/src/winusb
+++ b/src/winusb
@@ -364,7 +364,7 @@ trap "exitUmountIso '$isoMountPath' '$partitionMountPath' 'other signal'" HUP QU
 echo "Mounting..."
 mkdir -p "$isoMountPath"
 if [ -f "$isoPath" ]; then # ISO
-	mount -o loop -t iso9660 "$isoPath" "$isoMountPath"
+	mount -o loop "$isoPath" "$isoMountPath"
 else # Real DVD drive (block)
 	mount "$isoPath" "$isoMountPath"
 fi


### PR DESCRIPTION
Reverts slacka/WinUSB#2
Not all ISOs use ISO9660 file systems.