### PR TITLE
Specify i386-pc(MBR) mode when installing GRUB, fixes #1

### DIFF
--- a/src/winusb
+++ b/src/winusb
@@ -401,7 +401,7 @@ if [ -d "$partitionMountPath/Boot" ]; then mv "$partitionMountPath/Boot" "$parti
 
 # Grub
 echo "Installing grub..."
-grub-install --root-directory="$partitionMountPath" "$device" 
+grub-install --target=i386-pc --root-directory="$partitionMountPath" "$device" 
 
 uuid=$(blkid -o value -s UUID "$partition") 
 


### PR DESCRIPTION
GRUB installation command will fail if user's platform is not
i386-pc(thus x86_64-efi users will encounter "grub2-install: error:
/media/winusb_target_* doesn't look like an EFI partition." error), this
commit fixes the problem by specifying GRUB install mode/platform to
i386-pc.

NOTE:
* This patch is not fully tested, beware of regressions!
* This patch didn't implement test to check if GRUB's i386-pc platform
files exists in user's system.

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>