### PR TITLE
cli: fix winusb prematurely ended after the "Formating device..." message, fixes #10

### DIFF
--- a/src/winusb
+++ b/src/winusb
@@ -345,6 +345,8 @@ else
 	
 	blockdev --rereadpt "$device" || true # Reload partition table
 	partprobe "$device" # Reload partition table
+	echo "Wait 3 seconds for block device nodes to populate..."
+	sleep 3
 
 	# get first partition
 	partition=`ls --color=no -1 "$device"* | grep -ve "$device"'$'`


### PR DESCRIPTION
The `ls --color=no -1 /dev/sdc | grep -ve '/dev/sdc$'` command failed to
find any partitions after reading partition table, it seems that the
system needs more time to repopulate the new device nodes.

```
+ parted --align cylinder -s /dev/sdc mkpart primary 1MB 31.6GB
+ blockdev --rereadpt /dev/sdc
+ partprobe /dev/sdc
++ grep -ve '/dev/sdc$'
++ ls --color=no -1 /dev/sdc
+ partition=
```

This commit fixes the issue by pausing 3 seconds before detecting
partitions, however this fix should be improved by using more reliable
method to ensure that the system is ready.

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>