### PR TITLE
Debian packaging: Depend on grub-pc-bin, fixes #22

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.congelli.eu/
 
 Package: winusb
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, parted, coreutils, bash, grub-pc | grub-efi, gksu, ntfsprogs | ntfs-3g (>= 1:2011)
+Depends: ${shlibs:Depends}, ${misc:Depends}, parted, coreutils, bash, grub-pc | grub-efi, grub-pc-bin, gksu, ntfsprogs | ntfs-3g (>= 1:2011)
 Description: WinUSB can create bootable windows installer on usb.
  This package contains two programs:
   - WinUSB-gui: a simple tool that enable you to create


### PR DESCRIPTION
grub-pc-bin package is needed for EFI platform user to install PC/MBR
style GRUB boot loader.

We'll also need to depend on grub-efi-bin after UEFI booting support is
implemented in the future.

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>