### PR TITLE
Obselute of using --root-directory on grub-install, fixes #16

### DIFF
--- a/src/winusb
+++ b/src/winusb
@@ -397,13 +397,9 @@ progressCp "$isoMountPath" "$partitionMountPath"
 
 pulse on
 
-# boot dir should be lower case
-if [ -d "$partitionMountPath/BOOT" ]; then mv "$partitionMountPath/BOOT" "$partitionMountPath/boot"; fi
-if [ -d "$partitionMountPath/Boot" ]; then mv "$partitionMountPath/Boot" "$partitionMountPath/boot"; fi
-
 # Grub
 echo "Installing grub..."
-grub-install --target=i386-pc --root-directory="$partitionMountPath" "$device" 
+grub-install --target=i386-pc --boot-directory="$partitionMountPath" "$device" 
 
 uuid=$(blkid -o value -s UUID "$partition") 
 


### PR DESCRIPTION
It seems that the use of `--root-directory` option is deprecated in
`grub-install` command(there's no trace on the manual and manpage,
*although the option is still accepted with unknown reason*).

**UPDATE:** This option appears on the [GRUB (legacy?) 0.97
manual](https://www.gnu.org/software/grub/manual/legacy/Invoking-
grub_002dinstall.html) but not on 2.00's

We should replace it with the existing `--boot-directory` instead.

NOTE:
* Now grub will be install under $TARGET_MOUNTPOINT/grub
* This patch also removes

```
if [ -d "$partitionMountPath/BOOT" ]; then mv "$partitionMountPath/BOOT"
"$partitionMountPath/boot"; fi
if [ -d "$partitionMountPath/Boot" ]; then mv "$partitionMountPath/Boot"
"$partitionMountPath/boot"; fi
```

as grub files no longer being placed under $TARGET_MOUNTPOINT/Boot,
which is supposed to be storing Windows's bootloader.

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>