### PR TITLE
cli: Switch to use FAT filesystem, fixes #18, #15, #6

### DIFF
--- a/src/winusb
+++ b/src/winusb
@@ -145,7 +145,7 @@ function hideNoErr()
 function printHelp()
 {
 	echo "$scriptName usage" >&2
-	echo "Install a Windows ISO on an NTFS partition and edit MBR of the device" >&2
+	echo "Install a Windows ISO on an FAT partition and edit MBR of the device" >&2
 	echo "  $scriptName --install <iso path> <partition>" >&2
 	echo "  Example: $scriptName win7_amd64.iso /dev/sdd1" >&2
 	echo "" >&2
@@ -283,13 +283,13 @@ if [ ! $(id -u) = 0 ]; then
    echo "Warning: you should run this script as root!" >&2
 fi
 
-mkntfsProg=''
-if which 'mkntfs' > /dev/null; then
-	mkntfsProg='mkntfs'
-elif which 'make.ntfs' > /dev/null; then
-	mkntfsProg='mkfs.ntfs'
+mkdosfsProg=''
+if which 'mkdosfs' > /dev/null; then
+	mkdosfsProg='mkdosfs'
+elif which 'make.msdos' > /dev/null; then
+	mkdosfsProg='mkfs.msdos'
 else
-	echo 'Error: mkntfs or mkfs.ntfs program not found!' >&2
+	echo 'Error: mkdosfs or mkfs.msdos program not found!' >&2
 	exit 1
 fi
 
@@ -351,8 +351,8 @@ else
 	# get first partition
 	partition=`ls --color=no -1 "$device"* | grep -ve "$device"'$'`
 
-	# Create the ntfs partition
-	"$mkntfsProg" --quiet --fast --label 'Windows USB' "$partition"
+	# Create the FAT partition
+	"$mkdosfsProg" -n 'Windows USB' "$partition"
 fi
 
 isoMountPath="/media/winusb_iso_$(date +%s)_$$"
@@ -416,9 +416,9 @@ echo -n "" > "$cfgFilename"
 echo "echo '------------------------------------'" >> "$cfgFilename" 
 echo "echo '|      Windows USB - Loading...    |'" >> "$cfgFilename" 
 echo "echo '------------------------------------'" >> "$cfgFilename" 
-echo "insmod ntfs" >> "$cfgFilename" 
+echo "insmod fat" >> "$cfgFilename"
 echo "search --no-floppy --fs-uuid $uuid --set root" >> "$cfgFilename" 
-echo "chainloader +1" >> "$cfgFilename" 
+echo "ntldr /bootmgr" >> "$cfgFilename"
 echo "boot" >> "$cfgFilename" 
 
 # End


### PR DESCRIPTION
This is a derived issue of #15 , UEFI requires that the removable boot-able device using FAT~~32~~ filesystem(instead of NTFS, which WinUSB is currently using).

This commit deals with issue by switching the target filesystem to FAT:

* Replace NTFS format command to FAT's one(while dropping some non-critical options that is not available).
* Modify GRUB config to be FAT-compatible
    * It seems that NTFS format tool will install a BOOTMGR-compatible VBR while FAT's tool doesn't, so I changed to use GRUB's `ntldr` command instead of `chainloader +1` command
* Of course, replace all messages with NTFS to FAT

After this commit, WinUSB should automagically supports UEFI boot(and also SecureBoot as we're now using GRUB as PC/MBR bootloader and Windows signed BOOTMGR as EFI bootloader, whether to completely drop GRUB bootloader is left to issue #19 to deal with).

According to my test on Windows 7/Windows 10 ISO I suspect that UEFI support will be compatible with Windows >=8(Although Windows 7 installation media does has efi files it's not following UEFI removable bootable device spec and I'm currently failed to make it boot).

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>