### PR TITLE
Fix regression: grub.cfg path not fixed on commit 3f91011("Obselute of using --root-directory on grub-install, fixes #16"), fixes #26

### DIFF
--- a/src/winusb
+++ b/src/winusb
@@ -405,7 +405,7 @@ uuid=$(blkid -o value -s UUID "$partition")
 
 # grub.cfg 
 echo "Installing grub.cfg..."
-cfgFilename="$partitionMountPath/boot/grub/grub.cfg" 
+cfgFilename="$partitionMountPath/grub/grub.cfg" 
 mkdir -p "$(dirname "$cfgFilename")"
 echo -n "" > "$cfgFilename"
 


### PR DESCRIPTION
Oops, I forgot to fix grub.cfg path to /grub/grub.cfg on commit 3f91011, this patch fixes it.

GitHub-Issue: #26 
Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>