### PR TITLE
cli: Improve partition creation code

### DIFF
--- a/src/winusb
+++ b/src/winusb
@@ -329,8 +329,8 @@ else
 	parted -s "$device" mklabel msdos
 
 	# Create partiton
-	size=$(env LANG='C' parted -s "$device" print | grep ^Disk | cut -f2 -d':' | sed 's/\s//g')
-	parted --align cylinder -s "$device" mkpart primary 1MB "$size" # We start at 1MB for grub (it needs a post-mbr gap for its code)
+	# We start at 4MiB for grub (it needs a post-mbr gap for its code) and alignment of flash memery block erase segment in general, for details see http://www.gnu.org/software/grub/manual/grub.html#BIOS-installation and http://lwn.net/Articles/428584/
+	parted -s "$device" mkpart primary fat32 4MiB -- -1s
 	
 	blockdev --rereadpt "$device" || true # Reload partition table
 	partprobe "$device" # Reload partition table
@@ -341,7 +341,7 @@ else
 	partition=`ls --color=no -1 "$device"* | grep -ve "$device"'$'`
 
 	# Create the FAT partition
-	"$mkdosfsProg" -n 'Windows USB' "$partition"
+	"$mkdosfsProg" -F 32 -n 'Windows USB' "$partition"
 fi
 
 isoMountPath="/media/winusb_iso_$(date +%s)_$$"


### PR DESCRIPTION
This patch fixes the following issues:

1. Depend on parsing Parted output for deciding the maximum size of the
partition(may break if parted change its output)
2. Using a partition alignment that is not friendly to flash
memory(lower transfer speed and potentially higher memory cell wear-off,
refer http://lwn.net/Articles/428584/ ).
3. Not specifying partition type code(and Parted defaults it to
EXT*(83))

by:

1. Using '-1s' notation to specify the last sector of the drive.
2. Aligning partition to 4MiB boundary
3. Specifying FAT32 partition type

Reference:
* GNU Parted infodoc - 2.4.5 mkpart

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>