### PR TITLE
Update Debian build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: winusb
 Section: x11
 Priority: extra
 Maintainer: Colin GILLE / congelli501 <colingille@hotmail.com>
-Build-Depends: debhelper (>= 7), autotools-dev, libwxgtk2.8-dev
+Build-Depends: debhelper (>= 7), autotools-dev, libwxgtk2.8-dev (>= 2.8.4) | libwxgtk3.0-dev
 Standards-Version: 3.8.1
 Homepage: http://www.congelli.eu/
 


### PR DESCRIPTION
This commit:
* Adds WxWidgets 3 as one of WinUSB's build dependencies
* Specify WxWidgets 2's accepted version according to configure script
output.

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>