### PR TITLE
Update debian control file to depend on either grub-efi-i386 OR grub-efi-amd64

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.congelli.eu/
 
 Package: winusb
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, parted, coreutils, bash, grub-pc | grub-efi, grub-pc-bin, gksu, ntfsprogs | ntfs-3g (>= 1:2011)
+Depends: ${shlibs:Depends}, ${misc:Depends}, parted, coreutils, bash, grub-pc | grub-efi-amd64 | grub-efi-i386, grub-pc-bin, gksu, ntfsprogs | ntfs-3g (>= 1:2011)
 Description: WinUSB can create bootable windows installer on usb.
  This package contains two programs:
   - WinUSB-gui: a simple tool that enable you to create


### PR DESCRIPTION
Since adca4024 the debian control file depends on either grub-pc or grub-efi, however currently in Ubuntu grub-efi *only* depends on grub-efi-amd64 but not grub-efi-i386, which could cause dependency unsatisfied issues on i386-efi systems.

This commits changes the dependency to depend on grub-pc OR grub-efi-amd64 OR grub-efi-i386, to fix this problem, unfortunately I don't have any 32-bit UEFI system to test this patch.

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>