### PR TITLE
src/winusb: fix neededSpace calculation

### DIFF
--- a/src/winusb
+++ b/src/winusb
@@ -371,7 +371,7 @@ mount "$partition" "$partitionMountPath"
 freeSpace=$(df --block-size 1 "$partitionMountPath" | grep "$partition" | awk '{print $4}')
 neededSpace=$(du -s "$isoMountPath" --bytes | awk '{print $1}')
 
-((neededSpace = neededSpace + 1000 * 1000 * 30)) # 10Mio more for grub
+((neededSpace = neededSpace + 1000 * 1000 * 10)) # 10MB more for grub installation
 
 if [ "$neededSpace" -gt "$freeSpace" ]; then
 	echo "Error: Not enough free space on '$partition'!" >&2


### PR DESCRIPTION
Currently $neededSpace is added 30MB(1000 * 1000 * 30byte) instead of 10MB(1000 * 1000 * 10byte) like the comment indicated.

This patch change the value back to 10MB, on my system the grub installation only using 4.5MB space so this value is sufficient.

Also the comment has been improved.

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>