### PR TITLE
src/MainPanel.cpp: Remove redundant std::string construct

### DIFF
--- a/src/MainPanel.cpp
+++ b/src/MainPanel.cpp
@@ -240,7 +240,7 @@ void MainPanel::OnInstall(wxCommandEvent& event)
             iso = m_dvdDriveDevList.at(m_dvdDriveList->GetSelection());
         }
 
-        PipeManager pipe(std::string("gksudo --description 'WinUSB' -- sh -c 'winusb --noColor --forGui --format \"") + iso + "\" \"" + device + "\" 2>&1'");
+        PipeManager pipe("gksudo --description 'WinUSB' -- sh -c 'winusb --noColor --forGui --format \"" + iso + "\" \"" + device + "\" 2>&1'");
 
         wxProgressDialog *dialog = new wxProgressDialog(_("Installing..."), _("Please wait..."), 100, GetParent(), wxPD_APP_MODAL | wxPD_SMOOTH | wxPD_CAN_ABORT);
 


### PR DESCRIPTION
It seems that std::string() is same as string literal ("") and doesn't needed to be specifically declared/called.  I'm not pretty sure about this, please review.

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>