### PR TITLE
Fix gettext message catalog project id

### DIFF
--- a/src/locale/default.po
+++ b/src/locale/default.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: memwrite\n"
+"Project-Id-Version: winusb\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2011-07-14 00:07+0100\n"
 "PO-Revision-Date: 2011-07-14 00:07+0100\n"

--- a/src/locale/fr/LC_MESSAGES/trad.po
+++ b/src/locale/fr/LC_MESSAGES/trad.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: memwrite\n"
+"Project-Id-Version: winusb\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2011-07-14 00:08+0100\n"
 "PO-Revision-Date: 2011-07-14 00:13+0100\n"


### PR DESCRIPTION
Currently the message catalog's project id is set to "memwrite", which apparently is Congelli501's [another project](http://en.congelli.eu/prog_info_memwrite.html)'s id.  This commit reset the id to "winusb"

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>