### PR TITLE
src/MainPanel.cpp - redirect error stream to /dev/null, fix possible off-by-N error, fixes #57

### DIFF
--- a/src/MainPanel.cpp
+++ b/src/MainPanel.cpp
@@ -134,7 +134,7 @@ void MainPanel::RefreshListContent()
         {
             command << "all ";
         }
-        command << "2>&1";
+        command << "2>/dev/null";
 
         PipeManager pipe(command.str());
 
@@ -165,7 +165,7 @@ void MainPanel::RefreshListContent()
         m_dvdDriveDevList.clear();
         m_dvdDriveList->Clear();
 
-        PipeManager pipe(std::string("\"$(readlink -f '") + StrWxToStd(findFile(_T("data/listDvdDrive"))) + "')\" 2>&1");
+        PipeManager pipe(std::string("\"$(readlink -f '") + StrWxToStd(findFile(_T("data/listDvdDrive"))) + "')\" 2>/dev/null");
 
         while(! pipe.IsEof())
         {


### PR DESCRIPTION
Currently the error string are inserted as an item of the target device list, which may causes `winusbgui` selecting the wrong target device to --format because of [off-by-N error](https://en.wikipedia.org/wiki/Off-by-one_error).

`winusbgui` currently calls two external script, namely `src/data/listUsb` and `src/data/listDvdDrive` to acquire connected hardware information, which output to stdout with the following format:

```
<block device path>
<block device path> - <disk model acquired from sysfs> - <disk model acquired from `parted -s`>
```

Then `winusbgui` collects the first row to a C++ STL &lt;vector&gt; and a second row to a wxListBox `m_(usbStick | dvdDrive)List` and when installation triggered, retrieve the &lt;block device path&gt; according to the index of selected item in wxListBox then made it as `winusb`'s command-line argument.

However currently the statement that calls these external script redirected `stderr` stream to `stdout`:

```cpp
        std::stringstream command;
        command << "\"$(readlink -f '";
        command << StrWxToStd(findFile(_T("data/listUsb")));
        command << "')\" ";
        if(showAllChecked)
        {
            command << "all ";
        }
        command << "2>&1";

        PipeManager pipe(command.str());
```

...and in normal cases when `winusbgui` is run as a normal user instead of root the `parted -s` command will fail, generates an error message that will then be redirected to `stdout` and subsequently become an erroneous element of &lt;vector&gt; or WxList.

This commit fixes the problem by redirect error stream to /dev/null, refer popen(3) manpage.

This is considered a critical bug, however I'm lacking the knowledge to inspect what's going on in a C++ program memory using GDB so I'm also not sure if this patch is appropriate(or just making the problem even bigger), please review.

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>