### PR TITLE
Add EFI boot support for Windows 7 64-Bit

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.congelli.eu/
 
 Package: winusb
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, parted, coreutils, bash, grub-pc | grub-efi-amd64 | grub-efi-i386, grub-pc-bin, gksu, ntfsprogs | ntfs-3g (>= 1:2011)
+Depends: ${shlibs:Depends}, ${misc:Depends}, parted, coreutils, bash, grub-pc | grub-efi-amd64 | grub-efi-i386, grub-pc-bin, gksu, ntfsprogs | ntfs-3g (>= 1:2011), p7zip-full
 Description: WinUSB can create bootable windows installer on usb.
  This package contains two programs:
   - WinUSB-gui: a simple tool that enable you to create

--- a/src/winusb
+++ b/src/winusb
@@ -386,6 +386,17 @@ progressCp "$isoMountPath" "$partitionMountPath"
 
 pulse on
 
+# Copy the EFI file for Windows 7
+if ( grep -Eq "^MinServer=7[0-9]{3}\.[0-9]" "$isoMountPath/sources/cversion.ini") && [ -f "$isoMountPath/bootmgr.efi" ]; then
+	# It's Windows 7 with EFI support (and thus 64-Bit)
+	if command -v "7z" >/dev/null 2>&1; then
+		mkdir -p "$partitionMountPath/EFI/Boot"
+		7z e -so "$isoMountPath/sources/install.wim" "1/Windows/Boot/EFI/bootmgfw.efi" > "$partitionMountPath/EFI/Boot/bootx64.efi"
+	else
+		echo "Warning: '7z' utility missing, EFI booting might not work!" >&2
+	fi
+fi
+
 # Grub
 echo "Installing grub..."
 grub-install --target=i386-pc --boot-directory="$partitionMountPath" "$device" 


### PR DESCRIPTION
This adds UEFI boot support for Windows 7.  In PR #25 only added that for Windows >=8:
> According to my test on Windows 7/Windows 10 ISO I suspect that UEFI support will be compatible with Windows >=8(Although Windows 7 installation media does has efi files it's not following UEFI removable bootable device spec and I'm currently failed to make it boot).

The key is to extract the `bootmgfw.efi` file from `sources/install.wim` and move it to `EFI/Boot/Bootx64.efi`.

Downside is that this relies on [p7zip](http://p7zip.sourceforge.net/) for file extraction (and thus introduces a new dependency).

Also, I'm not completely sure if my Windows 7 detection mechanism is correct:

1. I assumed that the `MinServer` value in in `sources/cversion.ini` begins with `7` if we're dealing with Windows 7 and that this file exists in all relevant Windows versions.
2. If we're using Windows 7, `bootmgr.efi` does only exist if it has UEFI support and is 64-Bit (since 32-Bit Windows 7 has no UEFI support).

I can't really verify this assumptions. They are true for my *Windows 7 Pro 64-Bit* installation disk.