### PR TITLE
Debian packaging - don't hardcode parallel building, let user specify themselves instead

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -40,7 +40,7 @@ build-stamp:  config.status
 	dh_testdir
 
 	# Add here commands to compile the package.
-	$(MAKE) -j8
+	$(MAKE)
 
 	touch $@
 


### PR DESCRIPTION
Currently `debian/rules` hardcoded to use 8 build jobs in `make`'s invocation, it should rather be defined as `dpkg-buildpackage`'s --jobs parameter by user instead.

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>