### PR TITLE
Fix `winusb` manpage's typo

### DIFF
--- a/src/winusb.1
+++ b/src/winusb.1
@@ -7,7 +7,7 @@ winusb \- A simple command line tool to create Windows Installation's USB stick 
 .\" Syntax goes here. 
 .B winusb
 .SH DESCRIPTION
-launches the winusb programm. There are no command line switches yet.
+launches the winusb program. There are no command line switches yet.
 See winusb --help for more information.
 .SH AUTHOR
 .nf


### PR DESCRIPTION
Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>