### PR TITLE
--force is required to install grub with block lists in Debian Stretc…

### DIFF
--- a/src/winusb
+++ b/src/winusb
@@ -407,7 +407,7 @@ else
 	echo 'Error: grub-install or grub2-install program not found!' >&2
 	exit 1
 fi
-"$grubInsProg" --target=i386-pc --boot-directory="$partitionMountPath" "$device" 
+"$grubInsProg" --target=i386-pc --boot-directory="$partitionMountPath" --force "$device" 
 
 uuid=$(blkid -o value -s UUID "$partition") 
 


### PR DESCRIPTION
--force is required to install grub with block lists in Debian Stretch's Grub 2.02~beta3-3 otherwise grub-install fails.