### PR TITLE
use grub2-install when possible

### DIFF
--- a/src/winusb
+++ b/src/winusb
@@ -10,8 +10,9 @@ set -o nounset
 # Script path
 set +o nounset
 if [ "$scriptPath" = "" ]; then
-	scriptName=$(basename $(readlink -f $0)) # readlink -f $0 ne marche pas en cas de "source"
-	scriptPath=$(dirname $(readlink -f $0)) # readlink -f $0 ne marche pas en cas de "source"
+	# readlink -f $0 doesn't work when using "source"
+	scriptName=$(basename $(readlink -f $0))
+	scriptPath=$(dirname $(readlink -f $0))
 fi
 set -o nounset
 

--- a/src/winusb
+++ b/src/winusb
@@ -400,10 +400,12 @@ fi
 
 # Grub
 echo "Installing grub..."
-if which 'grub-install' &> /dev/null; then
-	grubInsProg='grub-install'
-elif which 'grub2-install' &> /dev/null; then
+if which 'grub2-install' &> /dev/null; then
 	grubInsProg='grub2-install'
+	grubcfgDir='grub2'
+elif which 'grub-install' &> /dev/null; then
+	grubInsProg='grub-install'
+	grubcfgDir='grub'
 else
 	echo 'Error: grub-install or grub2-install program not found!' >&2
 	exit 1
@@ -414,7 +416,7 @@ uuid=$(blkid -o value -s UUID "$partition")
 
 # grub.cfg 
 echo "Installing grub.cfg..."
-cfgFilename="$partitionMountPath/grub/grub.cfg" 
+cfgFilename="$partitionMountPath/$grubcfgDir/grub.cfg"
 mkdir -p "$(dirname "$cfgFilename")"
 echo -n "" > "$cfgFilename"
 


### PR DESCRIPTION
on openSUSE grub-install is actually unsupported, use grub2-install first.

Using grub2 changes the dir where grub.cfg is written, so update that too.